### PR TITLE
ci: add auto-assign Github Action

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,15 @@
+# .github/workflows/auto-author-assign.yml
+name: 'Auto Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: toshimaru/auto-author-assign@v3.0.1


### PR DESCRIPTION
### What

https://github.com/toshimaru/auto-author-assign

Same Github Action as on other OFF github repos