### PR TITLE
docs: force mkdocs deploy (to avoid errors)

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -22,4 +22,4 @@ jobs:
         run: pip install mkdocs mkdocs-material
       - run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Publish docs
-        run: mkdocs gh-deploy
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
### What

https://github.com/openfoodfacts/brand-images/actions/runs/24864275224/job/72796930315
```
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/runner/work/brand-images/brand-images/site
INFO    -  Documentation built in 0.28 seconds
WARNING -  Version check skipped: No version specified in previous deployment.
INFO    -  Copying '/home/runner/work/brand-images/brand-images/site' to 'gh-pages' branch and pushing to GitHub.
To https://github.com/openfoodfacts/brand-images
 ! [rejected]        gh-pages -> gh-pages (fetch first)
error: failed to push some refs to 'https://github.com/openfoodfacts/brand-images'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```