### PR TITLE
ci: add explicit permissions on 2 Github Action workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
     runs-on: ubuntu-slim

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/brand-images/security/code-scanning/1](https://github.com/openfoodfacts/brand-images/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix without changing behavior: define workflow-level permissions granting only what this PR-title validation action typically needs:

- `contents: read`
- `pull-requests: read`

This keeps functionality (reading PR metadata/title) while avoiding broad inherited write access.  
Change location: `.github/workflows/semantic-pr.yml`, immediately after the `on:` trigger block and before `jobs:`.

No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
