### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
     runs-on: ubuntu-slim


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/brand-images/security/code-scanning/5](https://github.com/openfoodfacts/brand-images/security/code-scanning/5)

Add an explicit `permissions` block at the workflow root so all jobs inherit restricted default token privileges unless overridden.  
For this workflow, the safest non-breaking baseline is:

- `contents: read`

This limits `GITHUB_TOKEN` scope while preserving behavior, since the release action is already authenticated via `RELEASE_PLEASE_TOKEN`.  
Edit `.github/workflows/release-please.yml` by inserting the `permissions` section between the `on:` trigger block and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
